### PR TITLE
Add admin/status button to recreate an empty (resource) index.

### DIFF
--- a/support/elasticsearch2_fetch.erl
+++ b/support/elasticsearch2_fetch.erl
@@ -24,6 +24,7 @@
     get/3,
     index/4,
     delete/3,
+    delete_index/2,
     bulk/2
     ]).
 
@@ -143,6 +144,23 @@ delete(Connection, Index, DocId) ->
                                   profile()),
             result(Result, Url)
     end.
+
+%% @doc Delete an index.
+-spec delete_index(Connection, Index) -> Result when
+    Connection :: elasticsearch2:connection(),
+    Index :: elasticsearch2:index(),
+    Result :: elasticsearch2:result().
+delete_index(Connection, Index) ->
+    Path = iolist_to_binary([
+            $/,
+            z_url:url_encode(z_convert:to_binary(Index))]),
+    Url = make_url(Connection, Path, []),
+    Result = httpc:request(delete,
+                          {Url, []},
+                          http_options(),
+                          options(),
+                          profile()),
+    result(Result, Url).
 
 
 %% @doc Bulk index or delete documensts.

--- a/templates/_admin_status.tpl
+++ b/templates/_admin_status.tpl
@@ -1,0 +1,16 @@
+<div class="form-group">
+    <div>
+        {% button class="btn btn-default" text=_"Delete Elastic Search page index"
+            action={confirm text=[
+                                _"Are you sure you want to delete the Elastic Search index?",
+                                "<br><br>",
+                                _"You will need to rebuild the search index to fill it again."
+                            ]
+                            ok=_"Delete"
+                            is_danger
+                            postback={delete_index}
+                            delegate=`mod_elasticsearch2`}
+        %}
+        <span class="help-block">{_ Sometimes the Elastic Search index can get out of sync with the database. This will delete and recreate an empty Elastic Search index. _} {_ Use <b>Rebuild search indices</b> to fill the newly created Elastic Search index. _}</span>
+    </div>
+</div>


### PR DESCRIPTION
This adds a button in de admin/status (for admins only) that:

- Drops the current (resource) index
- Recreates the index as an empty index

This is useful for situations where the Elastic index is out of sync with the PostgreSQL database.

See also https://github.com/driebit/mod_elasticsearch/pull/75