### PR TITLE
Add batched put/delete, add support for mixing type and id in the ES document id

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ z_search:search(
 Buffered put/delete
 -------------------
 
-Use the `mod_elasticsearch:put_doc` and `mod_elasticsearch2:delete_doc` routines to perform bulk put and delete requests.
+Use the `mod_elasticsearch2:put_doc` and `mod_elasticsearch2:delete_doc` routines to perform bulk put and delete requests.
 
 The requests are buffered for one second, or 500 commands, whatever comes first.
 

--- a/README.md
+++ b/README.md
@@ -148,21 +148,6 @@ After a command has been executed the following notification is emitted:
 }).
 ```
 
-Types and document ids
-----------------------
-
-ES7+ does not support document types. As the document types are often used to distinguish ids between sources (for example Adlib databases) there are routines to combine the type and id:
-
-```erlang
-DocId = mod_elasticsearch2:typed_id(Id, Type),
-{Id, Type} = mod_elasticsearch2:type_id_split(DocId)
-```
-
-The empty type and the `resource` type are not appended to the document id.
-
-The `_type` field is simulated in the library, the type itself should be stored in the `es_type` field of the stored document.
-
-
 Notifications
 -------------
 
@@ -229,6 +214,15 @@ On fetch of a document record the `_source.es_type` is copied to `_type`. This f
 written for Elastic 5.x.
 
 Likewise references to `_type` in queries are mapped to `es_type`.
+
+As the document types are often used to distinguish ids between sources (for example Adlib databases) there are routines to combine the type and id:
+
+```erlang
+DocId = mod_elasticsearch2:typed_id(Id, Type),
+{Id, Type} = mod_elasticsearch2:type_id_split(DocId)
+```
+
+The empty type and the `resource` type are not appended to the document id.
 
 
 Logging

--- a/README.md
+++ b/README.md
@@ -128,6 +128,41 @@ z_search:search(
 ).
 ```
 
+Buffered put/delete
+-------------------
+
+Use the `mod_elasticsearch:put_doc` and `mod_elasticsearch2:delete_doc` routines to perform bulk put and delete requests.
+
+The requests are buffered for one second, or 500 commands, whatever comes first.
+
+After a command has been executed the following notification is emitted:
+
+```erlang
+-record(elasticsearch_bulk_result, {
+    action :: put | delete,
+    doc_id :: binary(),
+    index :: binary(),
+    result :: binary(),
+    status :: 100..500,
+    error :: map() | undefined
+}).
+```
+
+Types and document ids
+----------------------
+
+ES7+ does not support document types. As the document types are often used to distinguish ids between sources (for example Adlib databases) there are routines to combine the type and id:
+
+```erlang
+DocId = mod_elasticsearch2:typed_id(Id, Type),
+{Id, Type} = mod_elasticsearch2:type_id_split(DocId)
+```
+
+The empty type and the `resource` type are not appended to the document id.
+
+The `_type` field is simulated in the library, the type itself should be stored in the `es_type` field of the stored document.
+
+
 Notifications
 -------------
 

--- a/include/elasticsearch2.hrl
+++ b/include/elasticsearch2.hrl
@@ -13,3 +13,15 @@
 -record(elasticsearch_options, {
     fallback = true :: boolean()
 }).
+
+
+%% Event sent after a bulk update or delete has been done.
+%% The error is set to 'undefined' for successful updates.
+-record(elasticsearch_bulk_result, {
+    action :: put | delete,
+    doc_id :: binary(),
+    index :: binary(),
+    result :: binary(),
+    status :: 100..500,
+    error :: map() | undefined
+}).

--- a/support/elasticsearch2.erl
+++ b/support/elasticsearch2.erl
@@ -2,7 +2,7 @@
 %% @copyright 2022 Driebit BV
 %% @doc Main interface functions for fetching and indexing documents with
 %% Elasticsearch.
-%% @enddoc
+%% @end
 
 %% Copyright 2022 Driebit BV
 %%
@@ -24,22 +24,33 @@
 -export([
     connection/1,
     index/1,
+    bulk/2,
     get_doc/2,
     get_doc/3,
     put_doc/2,
     put_doc/3,
     put_doc/4,
+
+    put_bulkcmd/2,
+    put_bulkcmd/3,
+    put_bulkcmd/4,
+    delete_bulkcmd/2,
+    delete_bulkcmd/3,
+
     put_mapping/2,
     put_mapping/3,
     delete_doc/2,
-    delete_doc/3
+    delete_doc/3,
+
+    fold/4,
+    fold/5
 ]).
 
 -type connection() :: #{ host := binary(), port := non_neg_integer() }.
 -type doc_id() :: binary() | string() | integer().
 -type index() :: binary() | string().
--type bulkcmd() :: {index, Index::binary(), DocId::binary(), Doc::map()}
-                 | {delete, Index::binary(), DocId::binary()}.
+-type bulkcmd() :: {index, index(), doc_id(), Doc::map()}
+                 | {delete, index(), doc_id()}.
 -type result() :: {ok, map()} | {error, reason()}.
 -type reason() :: request
                 | eacces
@@ -95,7 +106,7 @@ index(Context) ->
             Value
     end.
 
-%% Fetch a single document by type and Id
+%% @doc Fetch a single document by Id from the default index.
 -spec get_doc( DocId, Context ) -> Result when
     DocId :: doc_id(),
     Context :: z:context(),
@@ -103,8 +114,7 @@ index(Context) ->
 get_doc(DocId, Context) ->
     get_doc(index(Context), DocId, Context).
 
-
-%% Fetch a single document by type and Id
+%% @doc Fetch a single document by Id from the index.
 -spec get_doc( Index, DocId, Context ) -> Result when
     Index :: index(),
     DocId :: doc_id(),
@@ -125,8 +135,7 @@ get_doc(Index, DocId, Context) ->
             Error
     end.
 
-
-%% Create Elasticsearch mapping
+%% @doc Create Elasticsearch mapping
 -spec put_mapping( Doc, Context ) -> Result when
     Doc :: map(),
     Context :: z:context(),
@@ -142,7 +151,7 @@ put_mapping(Doc, Context) ->
 put_mapping(Index, Mapping, Context) ->
     elasticsearch2_fetch:request(connection(Context), put, [ Index, <<"_mapping">> ], [], Mapping).
 
-%% Save a resource to Elasticsearch
+%% @doc Save a Zotonic resource to Elasticsearch
 -spec put_doc( RscId, Context ) -> Result when
     RscId :: m_rsc:resource(),
     Context :: z:context(),
@@ -150,6 +159,7 @@ put_mapping(Index, Mapping, Context) ->
 put_doc(RscId, Context) ->
     put_doc(index(Context), RscId, Context).
 
+%% @doc Put a Zotonic resource in the index.
 -spec put_doc( Index, RscId, Context ) -> Result when
     Index :: index(),
     RscId :: m_rsc:resource(),
@@ -170,6 +180,7 @@ put_doc(Index, RscId, Context) ->
             end
     end.
 
+%% @doc Put a document in the index.
 -spec put_doc( Index, DocId, Doc, Context ) -> Result when
     Index :: index(),
     DocId :: doc_id(),
@@ -181,6 +192,63 @@ put_doc(Index, DocId, Data, Context) ->
     Data1 = z_notifier:foldl(#elasticsearch_put{ index = Index, type = Type, id = DocId }, Data, Context),
     elasticsearch2_fetch:index(connection(Context), Index, DocId, Data1).
 
+%% @doc Map a resource put to a elasticsearch bulk command.
+-spec put_bulkcmd(RscId, Context) -> Result when
+    RscId :: m_rsc:resource(),
+    Context :: z:context(),
+    Result :: {ok, bulkcmd()} | {error, enoent}.
+put_bulkcmd(RscId, Context) ->
+    put_bulkcmd(index(Context), RscId, Context).
+
+%% @doc Map a resource put to a elasticsearch bulk command.
+-spec put_bulkcmd(Index, RscId, Context) -> Result when
+    Index :: index(),
+    RscId :: m_rsc:resource(),
+    Context :: z:context(),
+    Result :: {ok, bulkcmd()} | {error, enoent}.
+put_bulkcmd(Index, RscId, Context) ->
+    case m_rsc:rid(RscId, Context) of
+        undefined ->
+            {error, enoent};
+        RId ->
+            case m_rsc:exists(RId, Context) of
+                true ->
+                    % All resource properties
+                    Doc = elasticsearch2_mapping:map_rsc(RId, Context),
+                    Type = maps:get(<<"es_type">>, Doc, maps:get(es_type, Doc, <<>>)),
+                    Doc1 = z_notifier:foldl(#elasticsearch_put{ index = Index, type = Type, id = RId }, Doc, Context),
+                    {ok, {index, Index, RId, Doc1}};
+                false ->
+                    {error, enoent}
+            end
+    end.
+
+-spec put_bulkcmd(Index, DocId, Doc, Context) -> Result when
+    Index :: index(),
+    DocId :: doc_id(),
+    Doc :: map() | binary(),
+    Context :: z:context(),
+    Result :: {ok, bulkcmd()}.
+put_bulkcmd(Index, DocId, Doc, _Context) ->
+    {ok, {index, Index, DocId, Doc}}.
+
+%% @doc Map a resource delete to a bulk command on the default index.
+-spec delete_bulkcmd(DocId, Context) -> {ok, bulkcmd()} when
+    DocId :: doc_id(),
+    Context :: z:context().
+delete_bulkcmd(DocId, Context) ->
+    delete_bulkcmd(index(Context), DocId, Context).
+
+%% @doc Map a delete to a bulk command.
+-spec delete_bulkcmd(Index, DocId, Context) -> {ok, bulkcmd()} when
+    Index :: index(),
+    DocId :: doc_id(),
+    Context :: z:context().
+delete_bulkcmd(Index, DocId, _Context) ->
+    {ok, {delete, Index, DocId}}.
+
+
+%% @doc Delete a document from the default index.
 -spec delete_doc( DocId, Context ) -> Result when
     DocId :: doc_id(),
     Context :: z:context(),
@@ -188,6 +256,7 @@ put_doc(Index, DocId, Data, Context) ->
 delete_doc(DocId, Context) ->
     delete_doc(index(Context), DocId, Context).
 
+%% @doc Delete a document from the index.
 -spec delete_doc(Index, DocId, Context ) -> Result when
     Index :: index(),
     DocId :: doc_id(),
@@ -196,3 +265,101 @@ delete_doc(DocId, Context) ->
 delete_doc(Index, DocId, Context) ->
     elasticsearch2_fetch:delete(connection(Context), Index, DocId).
 
+%% @doc Bulk insert/delete operation.
+-spec bulk(Commands, Context) -> Result when
+    Commands :: [ bulkcmd() ],
+    Context :: z:context(),
+    Result :: result().
+bulk(Commands, Context) ->
+    Connection = connection(Context),
+    elasticsearch2_fetch:bulk(Connection, Commands).
+
+
+%% @doc Using the scrolling API, loop over all documents in an index.
+%% The Accumulator is passed to the function, and the end-accumulator
+%% is returned.
+-spec fold(Index, Fun, Accumulator, Context) -> Result when
+    Index :: index(),
+    Fun :: fun( (Doc, Accumulator1, Context) -> any() )
+         | fun( (Doc, Context) -> any() ),
+    Doc :: map(),
+    Context :: any(),
+    Result :: {ok, Accumulator2} | {error, term()},
+    Accumulator :: any(),
+    Accumulator1 :: any(),
+    Accumulator2 :: any().
+fold(Index, Fun, Acc, Context) ->
+    Query = #{
+        <<"size">> => 100,
+        <<"sort">> => [
+            <<"_doc">>
+        ]
+    },
+    fold(Index, Query, Fun, Acc, Context).
+
+-spec fold(Index, Query, Fun, Accumulator, Context) -> Result when
+    Index :: index(),
+    Query :: map(),
+    Fun :: fun( (Doc, Accumulator1, Context) -> any() )
+         | fun( (Doc, Context) -> any() ),
+    Doc :: map(),
+    Context :: any(),
+    Result :: {ok, Accumulator2} | {error, term()},
+    Accumulator :: any(),
+    Accumulator1 :: any(),
+    Accumulator2 :: any().
+fold(Index, Query, Fun, Acc, Context) ->
+    Result = search_scroll(Index, Query, <<"1h">>, Context),
+    fold_loop(Result, Fun, Acc, Context).
+
+fold_loop({ok, #{
+        <<"hits">> := #{
+            <<"hits">> := []
+        }
+    }}, _Fun, Acc, _Context) ->
+    {ok, Acc};
+fold_loop({ok, #{
+        <<"_scroll_id">> := ScrollId,
+        <<"hits">> := #{
+            <<"hits">> := Docs,
+            <<"total">> := _Total
+        }
+    }}, Fun, Acc, Context) ->
+    % Handle Docs
+    lager:debug("fetched ~p docs", [ length(Docs) ]),
+    Acc1 = lists:foldl(
+        fun(Doc, DocAcc) ->
+            if
+                is_function(Fun, 2) ->
+                    Fun(Doc, Context),
+                    DocAcc;
+                is_function(Fun, 3) ->
+                    Fun(Doc, DocAcc, Context)
+            end
+        end,
+        Acc,
+        Docs),
+    Query = #{
+        <<"scroll">> => <<"10m">>,
+        <<"scroll_id">> => ScrollId
+    },
+    Next = search_scroll_next(Query, Context),
+    fold_loop(Next, Fun, Acc1, Context);
+fold_loop({ok, Other}, _Fun, _Acc, _Context) ->
+    lager:warning("Scroll returned unexpected: ~p", [ Other ]),
+    {error, Other};
+fold_loop({error, Reason} = Error, _Fun, _Acc, _Context) ->
+    lager:error("Scroll returned error: ~p", [ Reason ]),
+    Error.
+
+-spec search_scroll(binary(), map(), string()|binary(), z:context()) -> {ok, map()} | {error, term()}.
+search_scroll(Index, Query, Timeout, Context) ->
+    lager:debug("mod_elasticsearch2 (~s): ~s", [ Index, Query ]),
+    % io:format("~p:~p: (~s) ~n~p~n~n", [ ?MODULE, ?LINE, Index, ElasticQuery2 ]),
+    Connection = elasticsearch2:connection(Context),
+    QArgs = [ {<<"scroll">>, z_convert:to_binary(Timeout)} ],
+    elasticsearch2_fetch:request(Connection, post, [ Index, <<"_search">> ], QArgs, Query).
+
+search_scroll_next(Query, Context) ->
+    Connection = elasticsearch2:connection(Context),
+    elasticsearch2_fetch:request(Connection, post, [ <<"_search">>, <<"scroll">> ], [], Query).

--- a/support/elasticsearch2_admin.erl
+++ b/support/elasticsearch2_admin.erl
@@ -1,7 +1,7 @@
 %% @author Driebit <tech@driebit.nl>
 %% @copyright 2022 Driebit BV
 %% @doc Support function for the admin search query panel.
-%% @enddoc
+%% @end
 
 %% Copyright 2022 Driebit BV
 %%
@@ -43,4 +43,12 @@ event(#postback{message={elastic_query_preview, Opts}}, Context) ->
             S = z_search:search({QueryType, [{elastic_query, Q}, {index, Index}]}, Context),
             {Html, Context1} = z_template:render_to_iolist({cat, "_admin_query_preview.tpl"}, [{result,S}, {id, Id}], Context),
             z_render:update(DivId, Html, Context1)
+    end;
+event(#postback{ message={delete_index, _Args}}, Context) ->
+    case z_acl:is_admin(Context) of
+        true ->
+            mod_elasticsearch2:delete_recreate_index(Context),
+            z_render:growl(?__("Index has been recreated. Rebuild search indices to fill it.", Context), Context);
+        false ->
+            z_render:growl_error(?__("You need to be an admin to delete the Elastic Search index.", Context), Context)
     end.

--- a/support/elasticsearch2_mapping.erl
+++ b/support/elasticsearch2_mapping.erl
@@ -1,7 +1,7 @@
 %% @author Driebit <tech@driebit.nl>
 %% @copyright 2022 Driebit BV
 %% @doc Map resources to Elastic Search documents.
-%% @enddoc
+%% @end
 
 %% Copyright 2022 Driebit BV
 %%

--- a/support/elasticsearch2_query_rsc.erl
+++ b/support/elasticsearch2_query_rsc.erl
@@ -1,7 +1,7 @@
 %% @author Driebit <tech@driebit.nl>
 %% @copyright 2022 Driebit BV
 %% @doc Support for Zotonic query resources.
-%% @enddoc
+%% @end
 
 %% Copyright 2022 Driebit BV
 %%

--- a/support/elasticsearch2_search.erl
+++ b/support/elasticsearch2_search.erl
@@ -1,7 +1,7 @@
 %% @author Driebit <tech@driebit.nl>
 %% @copyright 2022 Driebit BV
 %% @doc Zotonic search handler for Elasticsearch
-%% @enddoc
+%% @end
 
 %% Copyright 2022 Driebit BV
 %%

--- a/templates/_admin_status.tpl
+++ b/templates/_admin_status.tpl
@@ -1,6 +1,6 @@
 <div class="form-group">
     <div>
-        {% button class="btn btn-default" text=_"Delete Elastic Search page index"
+        {% button class="btn btn-default" text=_"Delete Elastic Search page index..."
             action={confirm text=[
                                 _"Are you sure you want to delete the Elastic Search index?",
                                 "<br><br>",


### PR DESCRIPTION
See also: https://github.com/driebit/ginger/pull/716

Adds:

- mixing type and id in the document id (needed to support Adlib databases)
- bulk put / delete commands, buffered for 1 second
- fold function to fold over all records matching a query, unlimited by the max 10K results of ES paging