### PR TITLE
On creation of new alias, ensure any existing index is deleted.

### DIFF
--- a/support/elasticsearch2_index.erl
+++ b/support/elasticsearch2_index.erl
@@ -135,6 +135,7 @@ maybe_reindex(Alias, NewIndex, Context) ->
     Context :: z:context(),
     Result :: elasticsearch2:result().
 update_alias(Alias, VersionedIndex, undefined, Context) ->
+    delete_index(Alias, Context),
     Body = #{
         <<"actions">> => [
             #{


### PR DESCRIPTION
This fixes a problem where the alias could not be created if there is another index with the same name as the new alias