### PR TITLE
Use fulltext scoring for sort on match_objects term

### DIFF
--- a/include/elasticsearch2.hrl
+++ b/include/elasticsearch2.hrl
@@ -10,8 +10,10 @@
 
 %% @doc Search options
 %%      fallback: whether to fall back to PostgreSQL for non full-text searches.
+%%      return_score: return {id, score} tuples, otherwise only return id
 -record(elasticsearch_options, {
-    fallback = true :: boolean()
+    fallback = true :: boolean(),
+    return_score = false :: boolean()
 }).
 
 

--- a/support/elasticsearch2_mapping.erl
+++ b/support/elasticsearch2_mapping.erl
@@ -1,9 +1,9 @@
 %% @author Driebit <tech@driebit.nl>
-%% @copyright 2022 Driebit BV
+%% @copyright 2022-2023 Driebit BV
 %% @doc Map resources to Elastic Search documents.
 %% @end
 
-%% Copyright 2022 Driebit BV
+%% Copyright 2022-2023 Driebit BV
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -142,9 +142,17 @@ map_rsc(Id, Context) ->
         es_type => <<"resource">>,
         category => m_rsc:is_a(Id, Context),
         pivot_title => default_translation(proplists:get_value(title, RscProps), Context),
+        pivot_rtsv => map_rtsv(m_edge:objects(Id, Context)),
         incoming_edges => incoming_edges(Id, Context),
         outgoing_edges => outgoing_edges(Id, Context)
     }.
+
+map_rtsv(ObjectIds) ->
+    lists:map(
+        fun(Id) ->
+            <<" zpo", (integer_to_binary(Id))/binary>>
+        end,
+        ObjectIds).
 
 %% @doc Get dynamic language mappings, based on available languages.
 -spec dynamic_language_mapping(z:context()) -> list( map() ).


### PR DESCRIPTION
This fixes a problem where the sort order of match_objects was not according to the overlap in objects.
Also change the second sort term order to publication_start, which matches the sort order in mod_search.