### PR TITLE
Tune text queries for better scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Config keys:
    This config key defaults to `true`.
 
  * `mod_elasticsearch2.default_operator`  The default text operator for words in a query string.
-   This is either AND or OR.  Defaults to 'AND'.
+   This is either AND or OR.  Defaults to 'OR'.
 
  * `mod_elasticsearch2.no_automatic_wildcard` Automatically add wildcards to the words in a text
    search string. The rewrites `"The quick fox"` to `((the | the*) (quick | quick*) (fox | fox*)) | "the quick fox"`  Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ Or in your site config:
  * `mod_elasticsearch2.host`
  * `mod_elasticsearch2.port`
 
-Elastic search normally doesn't count hits beyond 10K. To enable or disable counting the real
-total number of hits set the config key:
+Config keys:
 
- * `mod_elasticsearch2.track_total_hits`
+ * `mod_elasticsearch2.track_total_hits` Elastic search normally doesn't count hits beyond 10K.
+   To enable or disable counting the real total number of hits set this config.
+   This config key defaults to `true`.
 
-This config key defaults to `true`.
+ * `mod_elasticsearch2.default_operator`  The default text operator for words in a query string.
+   This is either AND or OR.  Defaults to 'AND'.
+
+ * `mod_elasticsearch2.no_automatic_wildcard` Automatically add wildcards to the words in a text
+   search string. The rewrites `"The quick fox"` to `((the | the*) (quick | quick*) (fox | fox*)) | "the quick fox"`  Defaults to `true`.
 
 
 ### Elasticsearch security config

--- a/README.md
+++ b/README.md
@@ -31,13 +31,15 @@ Config keys:
 
  * `mod_elasticsearch2.track_total_hits` Elastic search normally doesn't count hits beyond 10K.
    To enable or disable counting the real total number of hits set this config.
-   This config key defaults to `true`.
+   Defaults to `true` (track total hits).
 
  * `mod_elasticsearch2.default_operator`  The default text operator for words in a query string.
-   This is either AND or OR.  Defaults to 'OR'.
+   This is either AND or OR. Defaults to 'OR'.
 
- * `mod_elasticsearch2.no_automatic_wildcard` Automatically add wildcards to the words in a text
-   search string. The rewrites `"The quick fox"` to `((the | the*) (quick | quick*) (fox | fox*)) | "the quick fox"`  Defaults to `true`.
+ * `mod_elasticsearch2.no_automatic_wildcard` Do not automatically add wildcards to the words
+   in a text search string. The rewrites `"The quick fox"` to 
+   `((the | the*) (quick | quick*) (fox | fox*)) | "the quick fox"`
+   Defaults to `false` (do add wildcards).
 
 
 ### Elasticsearch security config

--- a/support/elasticsearch2_search.erl
+++ b/support/elasticsearch2_search.erl
@@ -469,7 +469,7 @@ map_query({text, Text}, Context) ->
     DefaultOperator = case z_convert:to_upper(z_convert:to_binary(DefOpCfg)) of
         <<"AND">> = DefOp -> DefOp;
         <<"OR">> = DefOp -> DefOp;
-        _ -> <<"AND">>
+        _ -> <<"OR">>
     end,
     Query = case z_convert:to_bool(m_config:get_value(mod_elasticsearch2, no_automatic_wildcard, Context)) of
         true ->

--- a/support/elasticsearch2_search.erl
+++ b/support/elasticsearch2_search.erl
@@ -246,10 +246,33 @@ do_search(ElasticQuery, QArgs, ZotonicQuery, {From, Size}, Context) ->
     Connection = elasticsearch2:connection(Context),
     case elasticsearch2_fetch:request(Connection, post, [ Index, <<"_search">> ], QArgs, JSON) of
         {ok, Result} ->
+            % io:format("~p", [ scores(Result) ]),
+            case z_convert:to_bool(m_config:get_value(mod_elasticsearch2, log_scores, Context)) of
+                true ->
+                    lager:info("ES2 Query scores: ~p", [ scores(Result) ]);
+                false ->
+                    ok
+            end,
             search_result(Result, ElasticQuery2, ZotonicQuery, {From, Size});
         {error, _} ->
             #search_result{}
     end.
+
+scores(#{
+        <<"hits">> := #{
+            <<"hits">> := Docs
+        }
+    }) ->
+    lists:map(
+        fun(#{
+                <<"_id">> := Id,
+                <<"_score">> := Score
+            }) ->
+            {Score, Id}
+        end,
+        Docs);
+scores(_) ->
+    [].
 
 fix_type(Map) when is_map(Map) ->
     maps:fold(
@@ -448,20 +471,25 @@ map_query({text, Text}, Context) ->
                 <<"simple_query_string">> => #{
                     <<"query">> => Text,
                     <<"fields">> => Fields,
-                    <<"default_operator">> => <<"OR">>,
+                    <<"default_operator">> => <<"AND">>,
                     <<"flags">> => <<"ALL">>
                 }
             };
         false ->
             {SearchText, Ops} = add_wildcards(Text),
+            SearchText1 = iolist_to_binary([
+                    $(, SearchText, $),
+                    " | ",
+                    $", Text, $"
+                ]),
             #{
                 <<"simple_query_string">> => #{
-                    <<"query">> => SearchText,
+                    <<"query">> => SearchText1,
                     <<"fields">> => Fields,
-                    <<"default_operator">> => <<"OR">>,
+                    <<"default_operator">> => <<"AND">>,
                     <<"flags">> => case Ops of
                         default -> <<"ALL">>;
-                        prefix -> <<"PREFIX|WHITESPACE">>
+                        prefix -> <<"PREFIX|WHITESPACE|OR|PRECEDENCE">>
                     end
                 }
             }
@@ -781,12 +809,18 @@ is_with_operators(S) ->
 % split parts on space, add asterix for better search results
 add_wildcards_1(Text) ->
     Parts = binary:split(Text, <<" ">>, [ global, trim_all ]),
-    lists:flatten(
+    WsParts = lists:flatten(
         lists:map(
             fun(P) ->
-                [ P, <<P/binary, "*">> ]
+                [
+                    $(,
+                        P, " | ",
+                        <<P/binary, "*">>,
+                    $)
+                ]
             end,
-            Parts)).
+            Parts)),
+    WsParts.
 
 
 %% @doc Map pivot column name to regular property name.

--- a/support/elasticsearch2_search.erl
+++ b/support/elasticsearch2_search.erl
@@ -489,7 +489,7 @@ map_query({text, Text}, Context) ->
                     <<"default_operator">> => <<"AND">>,
                     <<"flags">> => case Ops of
                         default -> <<"ALL">>;
-                        prefix -> <<"PREFIX|WHITESPACE|OR|PRECEDENCE">>
+                        prefix -> <<"PREFIX|WHITESPACE|OR|PRECEDENCE|PHRASE">>
                     end
                 }
             }


### PR DESCRIPTION
Change the way we search for texts.

This fixes an issue where searching for a string in the Zuiderzeecollectie corpus didn't give a good order of result. The example query we optimized for was `henk van der leeden`.  The is resulted in many "henk", "van" and "der" objects, and the expected ones where the name is only mentioned in the body text lower in the results.

This is due to the change of the similarity algorithm in ES7. This change does not fit well with the content we have, where there are huge variations in length of the documents.

Changing the similarity algorithm needs much experimentation, and writes to the settings of the index.

To keep this simple we have now tuned the rewrite of the query text.  Previously we added prefix queries using 'OR' (as in ES7+ prefix queries are not scored, just 0 or 1 for a match or non-match).  Now we keep the order, changed to using 'AND' and added the whole search as a phrase match.

Changes:
 - Rewrite "The quick fox" to `((the | the*) (quick | quick*) (fox | fox*)) | "the quick fox"`
 - ~Change default operator from OR to AND~

To decide:

 - [x] Add config for default operator (AND vs OR)
 - [x] Should the default be AND or OR (used to be OR) --> Decided to make it ES default: OR